### PR TITLE
Update Dockerfiles

### DIFF
--- a/containers/bedtools__v2.30.0.Dockerfile
+++ b/containers/bedtools__v2.30.0.Dockerfile
@@ -39,6 +39,7 @@ COPY --from=builder "/tmp/bedtools2/LICENSE" "/usr/local/share/licenses/bedtools
 
 RUN apt-get update \
 &&  apt-get install -y bzip2 \
+                       procps \
                        xz-utils \
                        zlib1g \
 &&  rm -rf /var/lib/apt/lists/*

--- a/containers/comparative-analysis__v1.0.0.Dockerfile
+++ b/containers/comparative-analysis__v1.0.0.Dockerfile
@@ -18,6 +18,7 @@ RUN micromamba install -y \
                numpy \
                pandas \
                pigz \
+               procps-ng \
                pyBigWig \
 && micromamba clean --all -y
 

--- a/containers/cooltools__v0.5.4.Dockerfile
+++ b/containers/cooltools__v0.5.4.Dockerfile
@@ -20,6 +20,7 @@ RUN micromamba install -y \
         bioframe \
         "cooltools=$COOLTOOLS_VER" \
         ucsc-bedgraphtobigwig \
+        procps-ng \
 && micromamba clean --all -y
 
 ENV PATH="/opt/conda/bin:$PATH"

--- a/containers/dchic__vd4eb244.Dockerfile
+++ b/containers/dchic__vd4eb244.Dockerfile
@@ -43,7 +43,9 @@ COPY --from=patch_dchic --chown=nobody:nogroup /tmp/dchic/packages /opt/dchic/pa
 
 RUN cd /opt/dchic \
 && micromamba install -y -f packages/dchic.yml \
-&& micromamba install -y -c conda-forge pigz \
+&& micromamba install -y -c conda-forge \
+    pigz \
+    procps-ng \
 && micromamba clean --all -y \
 && R CMD INSTALL packages/functionsdchic_*.tar.gz
 

--- a/containers/diff-expression-analysis__v1.0.0.Dockerfile
+++ b/containers/diff-expression-analysis__v1.0.0.Dockerfile
@@ -34,6 +34,7 @@ RUN micromamba install -y                                              \
                r-optparse                                              \
                r-pheatmap                                              \
                r-stringr                                               \
+               procps-ng                                               \
 && micromamba clean --all -y
 
 RUN touch /opt/conda/lib/R/etc/.Rprofile

--- a/containers/diffdomain__v1c4b3db.Dockerfile
+++ b/containers/diffdomain__v1c4b3db.Dockerfile
@@ -41,6 +41,7 @@ RUN micromamba install -y \
         matplotlib \
         numpy \
         pandas \
+        procps-ng \
         seaborn \
         statsmodels \
         tqdm \

--- a/containers/functional-analysis__v1.0.0.Dockerfile
+++ b/containers/functional-analysis__v1.0.0.Dockerfile
@@ -53,6 +53,7 @@ RUN micromamba install -y                            \
                bioframe                              \
                gprofiler-official                    \
                numpy                                 \
+               procps-ng                             \
                scikit-learn                          \
                scipy                                 \
                seaborn                               \

--- a/containers/hic-balancing__v1.0.0.Dockerfile
+++ b/containers/hic-balancing__v1.0.0.Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update \
                       libtbb2 \
                       openjdk-18-jre \
                       pigz \
+                      procps \
                       python3 \
                       python3-pip \
                       zstd \

--- a/containers/hicexplorer__v3.7.2.Dockerfile
+++ b/containers/hicexplorer__v3.7.2.Dockerfile
@@ -19,6 +19,7 @@ RUN micromamba install -y \
         "python=3.9" \
         "cleanlab>=1,<2" \
         "hicexplorer=$HICEXPLORER_VER" \
+        procps-ng \
 && micromamba clean --all -y
 
 ENV PATH="/opt/conda/bin:$PATH"

--- a/containers/hicrep__v0.2.6.Dockerfile
+++ b/containers/hicrep__v0.2.6.Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
 && pip install "hicrep==$HICREP_VER" \
 && apt-get remove -y -q cython3 \
                          gcc \
+                         procps \
                          python3-dev \
                          python3-pip \
 && apt-get autoremove -y \

--- a/containers/maxhic__vb553b8f.Dockerfile
+++ b/containers/maxhic__vb553b8f.Dockerfile
@@ -38,6 +38,7 @@ RUN micromamba install -y \
         'cooler>=0.9' \
         'numpy>=1.4,<1.22' \
         'pandas>=0.24' \
+        procps-ng \
         'scipy>=1.1' \
         'tensorflow>=1.3,<2' \
 && micromamba clean --all -y

--- a/containers/microarray-analysis__v1.0.0.Dockerfile
+++ b/containers/microarray-analysis__v1.0.0.Dockerfile
@@ -19,6 +19,7 @@ RUN micromamba install -y \
         bioframe \
         numpy \
         pandas \
+        procps-ng \
         ucsc-liftover \
 && micromamba clean --all -y
 

--- a/containers/plotting__v1.0.0.Dockerfile
+++ b/containers/plotting__v1.0.0.Dockerfile
@@ -23,6 +23,7 @@ RUN micromamba install -y \
         natsort \
         numpy \
         pandas \
+        procps-ng \
         pyBigWig \
         r-alluvial \
         r-data.table \

--- a/containers/samtools__v1.17.Dockerfile
+++ b/containers/samtools__v1.17.Dockerfile
@@ -75,6 +75,7 @@ RUN apt-get update \
                       libdeflate0 \
                       libncurses5 \
                       lzma \
+                      procps \
                       zlib1g \
 && rm -rf /var/lib/apt/lists/*
 

--- a/containers/utils__v1.0.1.Dockerfile
+++ b/containers/utils__v1.0.1.Dockerfile
@@ -15,6 +15,7 @@ RUN dnf update -y \
                    gawk \
                    perl-Digest-SHA \
                    pigz \
+                   procps \
                    python3 \
                    rsync \
                    sed \


### PR DESCRIPTION
- [Bump mambaorg/micromamba from 1.3.1 to 1.4.0 in /containers](https://github.com/paulsengroup/2022-mcf10a-cancer-progression/commit/ff2f84f90fa875ced9ec4ac9d0b41c84a1116d5c)
- [Install procps in Dockerfiles to enable workflow tracing](https://github.com/paulsengroup/2022-mcf10a-cancer-progression/commit/6fd702ac59223ff96085711ead796ea52278fa6f)

I decided to not update Chrom3D's Dockerfile given that we currently have some long simulations running (that we do not want to re-run just because of some minor changes to the Dockerfile).

cc @mooshagh 